### PR TITLE
Fix chswift picking incorrect Swift

### DIFF
--- a/share/chswift/chswift.sh
+++ b/share/chswift/chswift.sh
@@ -68,7 +68,7 @@ function chswift()
 			for dir in "${XCODES[@]}"; do
 				case "`swift_version "$dir"`" in
 					"$1")	match="$dir" && break ;;
-					*"$1"*)	match="$dir" ;;
+					"$1"*)	match="$dir" ;;
 				esac
 			done
 


### PR DESCRIPTION
Guess what, Xcode 6.4's Swift `1.2 (swiftlang-602.0.53.1 clang-602.0.53)` matches `2.0` 😟
